### PR TITLE
:sparkles: Support calling provider plugins.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ temp
 # build and release
 dist
 csmctl
+csmctl-docker
 tmp/
 releases/

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ export GOBIN := $(abspath $(TOOLS_BIN_DIR))
 .PHONY: build
 build: # build the csmctl binary
 	go build -o csmctl main.go
+	go build -o csmctl-docker csmctldocker/csmctldocker_main.go
 
 .PHONY: lint-golang
 lint-golang: ## Lint Golang codebase

--- a/csmctldocker/csmctldocker_main.go
+++ b/csmctldocker/csmctldocker_main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	csmctlclusterstack "github.com/SovereignCloudStack/csmctl/pkg/clusterstack"
+)
+
+const provider = "docker"
+
+func usage() {
+	fmt.Printf(`%s create-node-images cluster-stack-directory cluster-stack-release-directory
+This command is a csmctl plugin.
+
+https://github.com/SovereignCloudStack/csmctl
+`, os.Args[0])
+}
+
+func main() {
+	if len(os.Args) != 4 {
+		usage()
+		os.Exit(1)
+	}
+	if os.Args[1] != "create-node-images" {
+		usage()
+		os.Exit(1)
+	}
+	clusterStackPath := os.Args[2]
+	config, err := csmctlclusterstack.GetCsmctlConfig(clusterStackPath)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	if config.Config.Provider.Type != provider {
+		fmt.Printf("Wrong provider in %s. Expected %s\n", clusterStackPath, provider)
+		os.Exit(1)
+	}
+	releaseDir := os.Args[3]
+	_, err = os.Stat(releaseDir)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	fmt.Printf("clusterStackPath: %s\n", clusterStackPath)
+	fmt.Printf("releaseDir: %s\n", releaseDir)
+	fmt.Println(".... pretending to do heavy work (creating node images) ...")
+}

--- a/csmctldocker/csmctldocker_main.go
+++ b/csmctldocker/csmctldocker_main.go
@@ -1,3 +1,23 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package main provides a dummy plugin for csmctl. You can use that code
+// to create a real csmctl plugin.
+// You can implement the "create-node-images" command to create node images during
+// a `csmclt create` call.
 package main
 
 import (

--- a/pkg/clusterstack/config.go
+++ b/pkg/clusterstack/config.go
@@ -36,9 +36,9 @@ type CsmctlConfig struct {
 		KubernetesVersion string `yaml:"kubernetesVersion"`
 		ClusterStackName  string `yaml:"clusterStackName"`
 		Provider          struct {
-			Type       string   `yaml:"type"`
-			APIVersion string   `yaml:"apiVersion"`
-			Config     struct{} `yaml:"config"`
+			Type       string                 `yaml:"type"`
+			APIVersion string                 `yaml:"apiVersion"`
+			Config     map[string]interface{} `yaml:"config"`
 		} `yaml:"provider"`
 	} `yaml:"config"`
 }

--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -88,7 +88,7 @@ func createAction(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get config: %w", err)
 	}
 
-	_, err = providerplugin.GetProviderExecutable(config)
+	_, _, err = providerplugin.GetProviderExecutable(config)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -88,7 +88,7 @@ func createAction(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get config: %w", err)
 	}
 
-	_, err = providerplugin.CheckProviderExecutable(config)
+	_, err = providerplugin.GetProviderExecutable(config)
 	if err != nil {
 		return err
 	}

--- a/pkg/providerplugin/providerplugin.go
+++ b/pkg/providerplugin/providerplugin.go
@@ -1,0 +1,40 @@
+package providerplugin
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/SovereignCloudStack/csmctl/pkg/clusterstack"
+)
+
+func CheckProviderExecutable(config *clusterstack.CsmctlConfig) (path string, err error) {
+	pluginName := "csmctl-" + config.Config.Provider.Type
+	_, err = os.Stat(pluginName)
+	if err == nil {
+		path, err := filepath.Abs(pluginName)
+		if err != nil {
+			return "", err
+		}
+		return path, err
+	}
+	path, err = exec.LookPath(pluginName)
+	if err != nil {
+		return "", fmt.Errorf("could not find plugin %s in $PATH or current working directory", pluginName)
+	}
+	return path, nil
+}
+
+func CreateNodeImages(config *clusterstack.CsmctlConfig, clusterStackPath string, clusterStackReleaseDir string) error {
+	path, err := CheckProviderExecutable(config)
+	if err != nil {
+		return err
+	}
+	args := []string{"create-node-images", clusterStackPath, clusterStackReleaseDir}
+	fmt.Printf("Calling Provider Plugin: %s\n", path)
+	cmd := exec.Command(path, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/pkg/providerplugin/providerplugin.go
+++ b/pkg/providerplugin/providerplugin.go
@@ -1,3 +1,20 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package providerplugin implements calling the provider specific csmctl plugin.
 package providerplugin
 
 import (
@@ -9,7 +26,8 @@ import (
 	"github.com/SovereignCloudStack/csmctl/pkg/clusterstack"
 )
 
-func CheckProviderExecutable(config *clusterstack.CsmctlConfig) (path string, err error) {
+// GetProviderExecutable returns the path to the provider plugin (like "csmctl-docker").
+func GetProviderExecutable(config *clusterstack.CsmctlConfig) (path string, err error) {
 	pluginName := "csmctl-" + config.Config.Provider.Type
 	_, err = os.Stat(pluginName)
 	if err == nil {
@@ -26,14 +44,15 @@ func CheckProviderExecutable(config *clusterstack.CsmctlConfig) (path string, er
 	return path, nil
 }
 
-func CreateNodeImages(config *clusterstack.CsmctlConfig, clusterStackPath string, clusterStackReleaseDir string) error {
-	path, err := CheckProviderExecutable(config)
+// CreateNodeImages calls the provider plugin command to create nodes images.
+func CreateNodeImages(config *clusterstack.CsmctlConfig, clusterStackPath, clusterStackReleaseDir string) error {
+	path, err := GetProviderExecutable(config)
 	if err != nil {
 		return err
 	}
 	args := []string{"create-node-images", clusterStackPath, clusterStackReleaseDir}
 	fmt.Printf("Calling Provider Plugin: %s\n", path)
-	cmd := exec.Command(path, args...)
+	cmd := exec.Command(path, args...) // #nosec G204
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()


### PR DESCRIPTION
# OLD

Sad, that we did not merge this PR earlier. There were a lot of conflicts with the main branch now. I created a new PR: https://github.com/SovereignCloudStack/csctl/pull/97

**What this PR does / why we need it**:

We need a way to call csmctl plugins which handle the provider specific parts (like creating node-images).

**Which issue(s) this PR fixes**

Fixes #4 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

