### PR TITLE
:seedling: use same file permissions for release assets

### DIFF
--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -208,7 +208,7 @@ func (c *CreateOptions) generateRelease() error {
 		return fmt.Errorf("failed to read cluster-addon-values.yaml: %w", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(c.ClusterStackReleaseDir, "cluster-addon-values.yaml"), clusterAddonData, os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath.Join(c.ClusterStackReleaseDir, "cluster-addon-values.yaml"), clusterAddonData, os.FileMode(0o644)); err != nil {
 		return fmt.Errorf("failed to write cluster-addon-values.yaml: %w", err)
 	}
 


### PR DESCRIPTION
Fixes https://github.com/SovereignCloudStack/csctl/issues/79

- **use same permissions for released cluster-stacks**
  we were having 0755 permissions for one file
  which was cluster-addon-values.yaml and this
  commit updates it so that we have the same
  permissions for all the files in release assets.
  
  Signed-off-by: kranurag7 <anurag.kumar@syself.com>