### PR TITLE
:bug: update ldflags to use csctl

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,4 +10,7 @@ builds:
       - arm64
     env:
       - CGO_ENABLED=0
-    ldflags: -w -s -X github.com/SovereignCloudStack/csmctl/pkg/cmd.Version={{.Version}} -X github.com/SovereignCloudStack/csmctl/pkg/cmd.Commit={{.Commit}}
+    ldflags:
+      - -s -w 
+      - -X 'github.com/SovereignCloudStack/csctl/pkg/cmd.Version={{.Version}}'
+      - -X 'github.com/SovereignCloudStack/csctl/pkg/cmd.Commit={{.Commit}}'


### PR DESCRIPTION
- **update ldflags to use csctl**
  this was missed during last renaming and we
  also need to adjust the ldflags after the
  renaming of the project.
  This commit does the same.
  
  Signed-off-by: kranurag7 <anurag.kumar@syself.com>