### PR TITLE
:sparkles: Support calling provider plugins.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ temp
 # build and release
 dist
 csctl
+csctl-docker
 tmp/
 releases/

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ clean: ## cleans the csctl binary
 .PHONY: build
 build: # build the csctl binary
 	go build -ldflags "$(LDFLAGS)" -o csctl main.go
+	go build -o csctl-docker csctldocker/csctldocker_main.go
 
 .PHONY: lint-golang
 lint-golang: ## Lint Golang codebase

--- a/csctldocker/csctldocker_main.go
+++ b/csctldocker/csctldocker_main.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package main provides a dummy plugin for csctl. You can use that code
+// to create a real csctl plugin.
+// You can implement the "create-node-images" command to create node images during
+// a `csctl create` call.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	csctlclusterstack "github.com/SovereignCloudStack/csctl/pkg/clusterstack"
+)
+
+const provider = "docker"
+
+func usage() {
+	fmt.Printf(`%s create-node-images cluster-stack-directory cluster-stack-release-directory
+This command is a csctl plugin.
+
+https://github.com/SovereignCloudStack/csctl
+`, os.Args[0])
+}
+
+func main() {
+	if len(os.Args) != 4 {
+		usage()
+		os.Exit(1)
+	}
+	if os.Args[1] != "create-node-images" {
+		usage()
+		os.Exit(1)
+	}
+	clusterStackPath := os.Args[2]
+	config, err := csctlclusterstack.GetCsctlConfig(clusterStackPath)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	if config.Config.Provider.Type != provider {
+		fmt.Printf("Wrong provider in %s. Expected %s\n", clusterStackPath, provider)
+		os.Exit(1)
+	}
+	releaseDir := os.Args[3]
+	_, err = os.Stat(releaseDir)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	fmt.Printf("clusterStackPath: %s\n", clusterStackPath)
+	fmt.Printf("releaseDir: %s\n", releaseDir)
+	fmt.Printf("..... pretending to read config: %s\n", config.Config.Provider.Config["dummyKey"])
+	fmt.Printf("..... pretending to do heavy work (creating node images) ...\n")
+}

--- a/docs/design.md
+++ b/docs/design.md
@@ -133,8 +133,8 @@ help				  print a overview of available flags etc.
 
 subcommands for provider:
 install				Installs a cluster-stack-release-provider at a version
-installed			Lists installed csmtcl release providers
-remove				removes a csmtcl release provider at a version `csmtcl provider remove docker <version>`
+installed			Lists installed csctl release providers
+remove				removes a csctl release provider at a version `csctl provider remove docker <version>`
 ```
 
 ## Modes

--- a/pkg/clusterstack/config.go
+++ b/pkg/clusterstack/config.go
@@ -37,9 +37,9 @@ type CsctlConfig struct {
 		KubernetesVersion string `yaml:"kubernetesVersion"`
 		ClusterStackName  string `yaml:"clusterStackName"`
 		Provider          struct {
-			Type       string   `yaml:"type"`
-			APIVersion string   `yaml:"apiVersion"`
-			Config     struct{} `yaml:"config"`
+			Type       string                 `yaml:"type"`
+			APIVersion string                 `yaml:"apiVersion"`
+			Config     map[string]interface{} `yaml:"config"`
 		} `yaml:"provider"`
 	} `yaml:"config"`
 }

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -31,12 +31,12 @@ var (
 
 var versionCmd = &cobra.Command{
 	Use:          "version",
-	Short:        "prints the latest version of csmctl",
+	Short:        "prints the latest version of csctl",
 	Run:          printVersion,
 	SilenceUsage: true,
 }
 
 func printVersion(_ *cobra.Command, _ []string) {
-	fmt.Println("csmctl version:", Version)
+	fmt.Println("csctl version:", Version)
 	fmt.Println("commit:", Commit)
 }

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package github
 
 import (

--- a/pkg/providerplugin/providerplugin.go
+++ b/pkg/providerplugin/providerplugin.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package providerplugin implements calling the provider specific csctl plugin.
+package providerplugin
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/SovereignCloudStack/csctl/pkg/clusterstack"
+)
+
+// GetProviderExecutable returns the path to the provider plugin (like "csctl-docker").
+// If there is not "config" for the provider in csctl.yaml, then "needed" is false and "path" is the empty string.
+func GetProviderExecutable(config *clusterstack.CsctlConfig) (needed bool, path string, err error) {
+	if len(config.Config.Provider.Config) == 0 {
+		return false, "", nil
+	}
+	pluginName := "csctl-" + config.Config.Provider.Type
+	_, err = os.Stat(pluginName)
+	if err == nil {
+		path, err := filepath.Abs(pluginName)
+		if err != nil {
+			return false, "", fmt.Errorf("filepath.Abs(%q) failed: %w", pluginName, err)
+		}
+		return true, path, nil
+	}
+	path, err = exec.LookPath(pluginName)
+	if err != nil {
+		return false, "", fmt.Errorf("could not find plugin %s in $PATH or current working directory", pluginName)
+	}
+	return true, path, nil
+}
+
+// CreateNodeImages calls the provider plugin command to create nodes images.
+func CreateNodeImages(config *clusterstack.CsctlConfig, clusterStackPath, clusterStackReleaseDir string) error {
+	needed, path, err := GetProviderExecutable(config)
+	if err != nil {
+		return err
+	}
+	if !needed {
+		fmt.Printf("No provider specifig configuration in csctl.yaml. No need to call a plugin for provider %q\n", config.Config.Provider.Type)
+		return nil
+	}
+	args := []string{"create-node-images", clusterStackPath, clusterStackReleaseDir}
+	fmt.Printf("Calling Provider Plugin: %s\n", path)
+	cmd := exec.Command(path, args...) // #nosec G204
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("cmd.Run() failed: %w", err)
+	}
+	return nil
+}

--- a/tests/cluster-stacks/docker/ferrol/csctl.yaml
+++ b/tests/cluster-stacks/docker/ferrol/csctl.yaml
@@ -5,3 +5,5 @@ config:
   provider:
     type: docker
     apiVersion: docker.csctl.clusterstack.x-k8s.io/v1alpha1
+    config:
+      dummyKey: dummyValue


### PR DESCRIPTION
**What this PR does / why we need it**:

We need a way to call csmctl plugins which handle the provider specific parts (like creating node-images).

**Which issue(s) this PR fixes**

Fixes #4 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Testing**

You can see how the provider plugin docker gets called with this command:

```
make build; ./csctl create tests/cluster-stacks/docker/ferrol -m hash   
```

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

