### PR TITLE
:seedling: csctl accepts "--node-image-registry" now 

### DIFF
--- a/csctldocker/csctldocker_main.go
+++ b/csctldocker/csctldocker_main.go
@@ -38,7 +38,9 @@ https://github.com/SovereignCloudStack/csctl
 }
 
 func main() {
-	if len(os.Args) != 4 {
+	numArgs := 5
+	if len(os.Args) != numArgs {
+		fmt.Printf("Wrong number of arguments. Expected %d got %d\n", numArgs, len(os.Args))
 		usage()
 		os.Exit(1)
 	}
@@ -62,8 +64,10 @@ func main() {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}
+	nodeImageRegistry := os.Args[4]
 	fmt.Printf("clusterStackPath: %s\n", clusterStackPath)
 	fmt.Printf("releaseDir: %s\n", releaseDir)
+	fmt.Printf("nodeImageRegistry: %s\n", nodeImageRegistry)
 	fmt.Printf("..... pretending to read config: %s\n", config.Config.Provider.Config["dummyKey"])
 	fmt.Printf("..... pretending to do heavy work (creating node images) ...\n")
 }

--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -51,8 +51,9 @@ var (
 )
 
 var (
-	mode            string
-	outputDirectory string
+	mode              string
+	outputDirectory   string
+	nodeImageRegistry string
 )
 
 // CreateOptions contains config for creating a release.
@@ -63,6 +64,7 @@ type CreateOptions struct {
 	Metadata               clusterstack.MetaData
 	CurrentReleaseHash     hash.ReleaseHash
 	LatestReleaseHash      hash.ReleaseHash
+	NodeImageRegistry      string
 }
 
 // createCmd represents the create command.
@@ -78,6 +80,7 @@ var createCmd = &cobra.Command{
 func init() {
 	createCmd.Flags().StringVarP(&mode, "mode", "m", "stable", "It defines the mode of the cluster stack manager")
 	createCmd.Flags().StringVarP(&outputDirectory, "output", "o", "./releases", "It defines the output directory in which the release artifacts will be generated")
+	createCmd.Flags().StringVarP(&nodeImageRegistry, "node-image-registry", "r", "", "It defines the node image registry. For example oci://ghcr.io/foo/bar/node-images/staging/")
 }
 
 // GetCreateOptions create a Create Option for create command.
@@ -147,6 +150,8 @@ func GetCreateOptions(ctx context.Context, clusterStackPath string) (*CreateOpti
 	}
 	// Release directory name `release/docker-ferrol-1-27-v1`
 	createOption.ClusterStackReleaseDir = filepath.Join(outputDirectory, releaseDirName)
+
+	createOption.NodeImageRegistry = nodeImageRegistry
 
 	return createOption, nil
 }
@@ -250,7 +255,10 @@ func (c *CreateOptions) generateRelease() error {
 		return fmt.Errorf("failed to write metadata: %w", err)
 	}
 
-	err = providerplugin.CreateNodeImages(&c.Config, c.ClusterStackPath, c.ClusterStackReleaseDir)
+	err = providerplugin.CreateNodeImages(&c.Config,
+		c.ClusterStackPath,
+		c.ClusterStackReleaseDir,
+		c.NodeImageRegistry)
 	if err != nil {
 		return fmt.Errorf("providerplugin.CreateNodeImages() failed: %w", err)
 	}

--- a/pkg/providerplugin/providerplugin.go
+++ b/pkg/providerplugin/providerplugin.go
@@ -49,16 +49,17 @@ func GetProviderExecutable(config *clusterstack.CsctlConfig) (needed bool, path 
 }
 
 // CreateNodeImages calls the provider plugin command to create nodes images.
-func CreateNodeImages(config *clusterstack.CsctlConfig, clusterStackPath, clusterStackReleaseDir string) error {
+func CreateNodeImages(config *clusterstack.CsctlConfig, clusterStackPath, clusterStackReleaseDir, nodeImageRegistry string) error {
 	needed, path, err := GetProviderExecutable(config)
 	if err != nil {
 		return err
 	}
 	if !needed {
-		fmt.Printf("No provider specifig configuration in csctl.yaml. No need to call a plugin for provider %q\n", config.Config.Provider.Type)
+		fmt.Printf("No provider specifig configuration in csctl.yaml. No need to call a plugin for provider %q\n",
+			config.Config.Provider.Type)
 		return nil
 	}
-	args := []string{"create-node-images", clusterStackPath, clusterStackReleaseDir}
+	args := []string{"create-node-images", clusterStackPath, clusterStackReleaseDir, nodeImageRegistry}
 	fmt.Printf("Calling Provider Plugin: %s\n", path)
 	cmd := exec.Command(path, args...) // #nosec G204
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
csctl accepts "--node-image-registry" now  and passes it to the plugin.

Example:
```
❯ make build; ./csctl create tests/cluster-stacks/docker/ferrol -m hash   --node-image-registry oci://ghcr.io/foo/bar/node-images/staging/
go build -ldflags "-X github.com/SovereignCloudStack/csctl/pkg/cmd.Version=v0.0.2-10-gbf1f8f0-dirty -X github.com/SovereignCloudStack/csctl/pkg/cmd.Commit=bf1f8f0a292e7dcf1a41c0c9b4dccd37ec5c4a09" -o csctl main.go
go build -o csctl-docker csctldocker/csctldocker_main.go
Creating output in releases/docker-ferrol-1-27-v0-sha-bf1f8f0
Calling Provider Plugin: /home/guettli/syself/csctl/csctl-docker
clusterStackPath: tests/cluster-stacks/docker/ferrol
releaseDir: releases/docker-ferrol-1-27-v0-sha-bf1f8f0
nodeImageRegistry: oci://ghcr.io/foo/bar/node-images/staging/     <=== output of plugin
..... pretending to read config: dummyValue
..... pretending to do heavy work (creating node images) ...
Created releases/docker-ferrol-1-27-v0-sha-bf1f8f0
```
**What this PR does / why we need it**:

For building node images the plugin needs to know the oci-registry.

The patch makes csctl accept the --node-image-registry flag. It gets passed to the plugin, too.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #100 


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

