### PR TITLE
:seedling: Update CsctlConfig struct

### DIFF
--- a/csctldocker/csctldocker_main.go
+++ b/csctldocker/csctldocker_main.go
@@ -64,6 +64,6 @@ func main() {
 	}
 	fmt.Printf("clusterStackPath: %s\n", clusterStackPath)
 	fmt.Printf("releaseDir: %s\n", releaseDir)
-	fmt.Printf("..... pretending to read config: %s\n", config.Config.Provider.Config["dummyKey"])
+	fmt.Printf("..... pretending to read config: %s\n", config.Config.Provider.Config.Method)
 	fmt.Printf("..... pretending to do heavy work (creating node images) ...\n")
 }

--- a/pkg/clusterstack/config.go
+++ b/pkg/clusterstack/config.go
@@ -37,9 +37,12 @@ type CsctlConfig struct {
 		KubernetesVersion string `yaml:"kubernetesVersion"`
 		ClusterStackName  string `yaml:"clusterStackName"`
 		Provider          struct {
-			Type       string                 `yaml:"type"`
-			APIVersion string                 `yaml:"apiVersion"`
-			Config     map[string]interface{} `yaml:"config"`
+			Type       string `yaml:"type"`
+			APIVersion string `yaml:"apiVersion"`
+			Config     struct {
+				Method string    `yaml:"method"`
+				Images []*string `yaml:"images,omitempty"`
+			} `yaml:"config"`
 		} `yaml:"provider"`
 	} `yaml:"config"`
 }

--- a/pkg/providerplugin/providerplugin.go
+++ b/pkg/providerplugin/providerplugin.go
@@ -29,7 +29,7 @@ import (
 // GetProviderExecutable returns the path to the provider plugin (like "csctl-docker").
 // If there is not "config" for the provider in csctl.yaml, then "needed" is false and "path" is the empty string.
 func GetProviderExecutable(config *clusterstack.CsctlConfig) (needed bool, path string, err error) {
-	if len(config.Config.Provider.Config) == 0 {
+	if config.Config.Provider.Config.Method == "" {
 		return false, "", nil
 	}
 	pluginName := "csctl-" + config.Config.Provider.Type


### PR DESCRIPTION
**What this PR does / why we need it**:
Based on this [hedgedoc](https://input.scs.community/csctl-plugin-openstack), we want to have field `Method` and `Images` under the `Provider.Config`

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

