### PR TITLE
✨ Overwrite helm chart version. No need for templating.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ csctl
 csctl-docker
 tmp/
 releases/
+.tmp
+.release
+.envrc
+dist/

--- a/tests/cluster-stacks/docker/ferrol/cluster-addon/Chart.yaml
+++ b/tests/cluster-stacks/docker/ferrol/cluster-addon/Chart.yaml
@@ -11,4 +11,5 @@ maintainers:
   url: https://github.com/syself
 name: docker-ferrol-1-27-cluster-addon
 type: application
-version: << .ClusterAddonVersion >>
+# version will be overwritten by csctl
+version: v0

--- a/tests/cluster-stacks/docker/ferrol/cluster-class/Chart.yaml
+++ b/tests/cluster-stacks/docker/ferrol/cluster-class/Chart.yaml
@@ -6,4 +6,5 @@ maintainers:
   url: https://github.com/syself
 name: docker-ferrol-1-27-cluster-class
 type: application
-version: << .ClusterClassVersion >>
+# version will be overwritten by csctl
+version: v0


### PR DESCRIPTION
this commit adds a feature in csctl where one doesn't require templating and Chart.yaml and csctl will override the version field in Chart.yaml

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

