### PR TITLE
:bug: Init nil metadata

### DIFF
--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -128,6 +128,8 @@ func GetCreateOptions(ctx context.Context, clusterStackPath string) (*CreateOpti
 	case hashMode:
 		createOption.Metadata = clusterstack.HandleHashMode(createOption.CurrentReleaseHash, config.Config.KubernetesVersion)
 	case stableMode:
+		createOption.Metadata = &clusterstack.MetaData{}
+
 		gc, err := client.NewFactory().NewClient(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create new github client: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Initialize nil Metadata to avoid nil pointer errors in stable mode

**Which issue(s) this PR fixes**:
Fixes #138

**TODOs**:

- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

