### PR TITLE
:bug: Add correct K8s version in metadata.yaml

### DIFF
--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -135,9 +135,6 @@ func GetCreateOptions(ctx context.Context, clusterStackPath string) (*CreateOpti
 			return nil, fmt.Errorf("failed to create new github client: %w", err)
 		}
 
-		// update the metadata kubernetes version with the csctl.yaml config
-		createOption.Metadata.Versions.Kubernetes = config.Config.KubernetesVersion
-
 		latestRepoRelease, err := github.GetLatestReleaseFromRemoteRepository(ctx, mode, config, gc)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get latest release form remote repository: %w", err)
@@ -159,6 +156,9 @@ func GetCreateOptions(ctx context.Context, clusterStackPath string) (*CreateOpti
 			if err != nil {
 				return nil, fmt.Errorf("failed to handle stable mode: %w", err)
 			}
+
+			// update the metadata kubernetes version with the csctl.yaml config
+			createOption.Metadata.Versions.Kubernetes = config.Config.KubernetesVersion
 		}
 	case customMode:
 		if clusterStackVersion == "" {

--- a/tests/cluster-stacks/docker/valencia/cluster-addon/metrics-server/overwrite.yaml
+++ b/tests/cluster-stacks/docker/valencia/cluster-addon/metrics-server/overwrite.yaml
@@ -1,5 +1,4 @@
-values: |
-  metrics-server:
-    commonLabels:
-      domain: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
-      clusterAddonVersion: "v2"
+metrics-server:
+  commonLabels:
+    domain: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
+    clusterAddonVersion: "v2"

--- a/tests/cluster-stacks/docker/valencia/cluster-class/Chart.yaml
+++ b/tests/cluster-stacks/docker/valencia/cluster-class/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 description: |
   This chart installs and configures:
-  * Docker Ferrol Cluster Class
+  * Docker Valencia Cluster Class
 maintainers:
   - name: Syself
     email: info@syself.com
     url: https://github.com/syself
-name: docker-ferrol-1-27-cluster-class
+name: docker-valencia-1-27-cluster-class
 type: application
 version: << .ClusterAddonVersion >>


### PR DESCRIPTION
**What this PR does / why we need it**:
We have overwritten the K8s version of the new cluster stack release by the one in the old release. This commit makes sure that we don't overwrite it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #140

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

