### PR TITLE
:bug: Fix version bumps in stable mode

### DIFF
--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -152,6 +152,11 @@ func GetCreateOptions(ctx context.Context, clusterStackPath string) (*CreateOpti
 				return nil, fmt.Errorf("failed to download release asset: %w", err)
 			}
 
+			createOption.LatestReleaseHash, err = hash.ParseReleaseHash("./.tmp/release/hashes.json")
+			if err != nil {
+				return nil, fmt.Errorf("failed to read hash from the github: %w", err)
+			}
+
 			createOption.Metadata, err = clusterstack.HandleStableMode("./.tmp/release/", createOption.CurrentReleaseHash, createOption.LatestReleaseHash)
 			if err != nil {
 				return nil, fmt.Errorf("failed to handle stable mode: %w", err)

--- a/pkg/github/release.go
+++ b/pkg/github/release.go
@@ -36,7 +36,7 @@ func DownloadReleaseAssets(ctx context.Context, releaseTag, downloadPath string,
 		return fmt.Errorf("failed to fetch release tag %s with status code %d", releaseTag, resp.StatusCode)
 	}
 
-	assetlist := []string{"metadata.yaml", "cluster-addon-values.yaml", "cluster-addon", "cluster-class"}
+	assetlist := []string{"hashes.json", "metadata.yaml", "cluster-addon-values.yaml", "cluster-addon", "cluster-class"}
 
 	if err := gc.DownloadReleaseAssets(ctx, repoRelease, downloadPath, assetlist); err != nil {
 		// if download failed for some reason, delete the release directory so that it can be retried in the next reconciliation

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -20,6 +20,7 @@ package hash
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -41,6 +42,21 @@ type ReleaseHash struct {
 	ClusterAddonDir    string `json:"clusterAddonDir"`
 	ClusterAddonValues string `json:"clusterAddonValues"`
 	NodeImageDir       string `json:"nodeImageDir,omitempty"`
+}
+
+// ParseReleaseHash parses the cluster-stack release hash.
+func ParseReleaseHash(path string) (ReleaseHash, error) {
+	latestGitHubReleaseHashData, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return ReleaseHash{}, fmt.Errorf("failed to read hash: %q: %w", path, err)
+	}
+
+	var releaseHash ReleaseHash
+	if err := json.Unmarshal(latestGitHubReleaseHashData, &releaseHash); err != nil {
+		return ReleaseHash{}, fmt.Errorf("failed to unmarshal json: %q: %w", path, err)
+	}
+
+	return releaseHash, nil
 }
 
 // GetHash returns the release hash.


### PR DESCRIPTION
**What this PR does / why we need it**:
In stable mode, we don't want to bump the dependencies if we don't have to, i.e. cluster addons and node images.

For this, we compare the hashes. However, we forgot to set up the inputs to the functions that do that correctly and one value was empty.

**Which issue(s) this PR fixes**:
Fixes #143

**TODOs**:
- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

