### PR TITLE
:bug: Update to go-1.25 to fix renovate/golang-deps

### DIFF
--- a/.github/renovate/golang.json5
+++ b/.github/renovate/golang.json5
@@ -4,7 +4,7 @@
   },
   // https://docs.renovatebot.com/configuration-options/#constraints
   "constraints": {
-    "go": "1.22"
+    "go": "1.25"
   },
   packageRules: [
     {

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.22"
+  go: "1.25"
   modules-download-mode: vendor
   allow-parallel-runners: true
 linters:


### PR DESCRIPTION
Move go to 1.25 to fix linting.