### PR TITLE
🌱 Don't run make targets for pr-lint on pull_request_target

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,7 +1,7 @@
 name: "Lint Pull Request"
 on: # yamllint disable-line rule:truthy
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
     paths:
       - "**.go"
@@ -16,7 +16,7 @@ on: # yamllint disable-line rule:truthy
 jobs:
   pr-lint:
     name: "Lint Pull Request"
-    if: github.event_name != 'pull_request_target' || !github.event.pull_request.draft
+    if: !github.event.pull_request.draft
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/sovereigncloudstack/csctl-builder:0.2.3


### PR DESCRIPTION
* although the rule `if: github.event_name != 'pull_request_target'` makes sure to not run the pr-lint steps on pull_request_target, we should not use this event trigger, but actually use `pull_request` instead
* https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target
